### PR TITLE
fixed Pigeon connection to Talon

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -102,7 +102,7 @@ public class Robot extends TimedRobot {
 
   private int leftEncoderReading = 159;
   private int rightEncoderReading = 314;
-  private PigeonIMU pigeonIMU = new PigeonIMU(0);
+  private PigeonIMU pigeonIMU = new PigeonIMU(leftMotorControllerCIM1);
   private double [] pigeonIMUData;
 
   private double robotHeading;


### PR DESCRIPTION
To configure a Pigeon connected via the data cable, you have to put the Talon object in as the input channel instead of the ID of the device.

This doesn't work:
private PigeonIMU pigeonIMU = new PigeonIMU(0);

...but this does:
private PigeonIMU pigeonIMU = new PigeonIMU(leftMotorControllerCIM1);